### PR TITLE
Add promoted/unpromoted states

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ OPTIONS (= is mandatory):
         'Stopped' - waits for resource to reach 'Stopped' state
         'Master' - waits for resource to reach 'Master' state
         'Slave' - waits for resource to reach 'Slave' state
+        'Promoted' - waits for resource to reach 'Promoted' state
+        'Unpromoted' - waits for resource to reach 'Unpromoted' state
         (Choices: present, absent, Started, Stopped, Master,
-        Slave)[Default: present]
+        Slave, Promoted, Unpromoted)[Default: present]
         type: str
 
 - timeout

--- a/library/crm_wait_for.py
+++ b/library/crm_wait_for.py
@@ -64,7 +64,7 @@ options:
     default: 2
   node_list:
     description:
-      - "List of nodes on which the desired stated is expected (only for 'Started'/'Stopped'/'Master'/'Slave' states."
+      - "List of nodes on which the desired stated is expected (only for 'Started'/'Stopped'/'Master'/'Slave'/'Promoted'/'Unpromoted' states."
       - "For state 'Stopped' the default is 'all cluster nodes', while for other states the default is 'any node'."
     required: false
     default: []
@@ -131,7 +131,7 @@ cluster_nodes:
   type: list
   sample: ['node-a', 'node-b']
 rsc_active_node_set:
-  description: (Only present when state is 'Stopped'/'Started'/'Master'/'Slave'). List of nodes where resource is in desired state.
+  description: (Only present when state is 'Stopped'/'Started'/'Master'/'Slave'/'Promoted'/'Unpromoted'). List of nodes where resource is in desired state.
   returned: always
   type: list
   sample: ['node-b']
@@ -163,7 +163,7 @@ def get_crm_data(module):
 def run_module():
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(default="present", choices=['present', 'absent', 'Started', 'Stopped', 'Master', 'Slave']),
+            state=dict(default="present", choices=['present', 'absent', 'Started', 'Stopped', 'Master', 'Slave', 'Promoted', 'Unpromoted']),
             resource=dict(required=True),
             delay=dict(type='int', default=0),
             timeout=dict(type='int', default=60),


### PR DESCRIPTION
As per request on https://github.com/OndrejHome/ansible_collection.ha_cluster/issues/4#issuecomment-3124227585, here is the PR fixing missing states on crm_wait_for.

I also updated documentation to match this update.